### PR TITLE
Fix Sonic Blast Video freeze at exit

### DIFF
--- a/yabause/src/sh2idle.c
+++ b/yabause/src/sh2idle.c
@@ -617,6 +617,7 @@ void FASTCALL SH2idleParse( SH2_struct *context, u32 cycles ) {
       }   
     }
     opcodes[context->instruction](context);
+    if ( context->cycles >= cycles ) return;
   }
 }
 


### PR DESCRIPTION
The idle check shall exit in case we are out of cycle budget. Otherwise, it might enter an endless loop.
Fix #330 