### PR TITLE
End codes are 0xFF - Fix Mortal Kombat texture

### DIFF
--- a/yabause/src/vidogl.c
+++ b/yabause/src/vidogl.c
@@ -956,7 +956,7 @@ static void FASTCALL Vdp1ReadTexture(vdp1cmd_struct *cmd, YglSprite *sprite, Ygl
         dot = T1ReadByte(Vdp1Ram, charAddr & 0x7FFFF);
                charAddr++;
                if ((dot == 0) && !SPD) *texture->textdata++ = 0x00;
-               else if( (dot == 0x3F) && !END ) *texture->textdata++ = 0x00;
+               else if( (dot == 0xFF) && !END ) *texture->textdata++ = 0x00;
          else if (MSB_SHADOW){
            *texture->textdata++ = (0x80)<< 24;
          }
@@ -1003,7 +1003,7 @@ static void FASTCALL Vdp1ReadTexture(vdp1cmd_struct *cmd, YglSprite *sprite, Ygl
                charAddr++;
 
                if ((dot == 0) && !SPD) *texture->textdata++ = 0x00;
-               else if( (dot == 0x7F) && !END ) *texture->textdata++ = 0x00;
+               else if( (dot == 0xFF) && !END ) *texture->textdata++ = 0x00;
          else if (MSB_SHADOW){
            *texture->textdata++ = (0x80) << 24;
          }


### PR DESCRIPTION
End codes are bad. I changed the values and aligned to VDP1 datasheet.
It is fixing at least Mortal Kombat Textures.

Fix #358 