### PR TITLE
Fix compilation on Linux

### DIFF
--- a/yabause/src/scsp.c
+++ b/yabause/src/scsp.c
@@ -5404,7 +5404,7 @@ void ScspAsynMain( void * p ){
         sleeptime = ((16666666L / frame_div) - difftime);
         if(initsleeptime==0){initsleeptime = sleeptime; initnow = now; }
         if( sleeptime < 0 ) break;
-#if defined(ARCH_IS_LINUX)
+#if defined(ANDROID)
         tm.tv_sec = 0;
         tm.tv_nsec = sleeptime;
         pthread_mutex_lock(&sync_mutex);

--- a/yabause/src/vidogl.c
+++ b/yabause/src/vidogl.c
@@ -45,7 +45,7 @@ int fount = 0;
 FILE *ppfp = NULL;
 #endif
 
-#ifdef _WINDOWS
+#ifndef ANDROID
 int yprintf(const char * fmt, ...)
 {
   static FILE * dbugfp = NULL;
@@ -61,7 +61,9 @@ int yprintf(const char * fmt, ...)
   }
   return 0;
 }
+#endif
 
+#ifdef _WINDOWS
 void OSDPushMessageDirect(char * msg) {
 }
 


### PR DESCRIPTION
Fixes issues #497 (pthread_cond_timedwait_relative_np only exists on android as far as I can tell) and #470 (fix was already published on that issue). Works on Arch Linux with gcc 7.3.0.