### PR TITLE
fix libretro port

### DIFF
--- a/yabause/src/ygles.c
+++ b/yabause/src/ygles.c
@@ -3603,8 +3603,8 @@ void YglRender(void) {
 
      if (_Ygl->clear_r != 0.0 &&  _Ygl->clear_g != 0.0 && _Ygl->clear_b != 0.0) {
        glClearColor(_Ygl->clear_r, _Ygl->clear_g, _Ygl->clear_b, 1.0f);
-       glClear(GL_COLOR_BUFFER_BIT);
      }
+     glClear(GL_COLOR_BUFFER_BIT);
    }
    
    if (_Ygl->texture_manager == NULL) goto render_finish;


### PR DESCRIPTION
I'm not sure this PR is ok, however it seems the libretro port won't cleanup previous frame correctly without it, the issue appeared in https://github.com/devmiyax/yabause/commit/66e95a8c029f0275215291f6bfcd929fb10bcb3c .
Theory : it might be related to the fact the libretro port can't use `YAB_ASYNC_RENDERING` ? (the libretro ecosystem is not friendly with programs rendering opengl from sub-threads)