### PR TITLE
Update external_libpng.cmake

### DIFF
--- a/yabause/src/glfw/external_libpng.cmake
+++ b/yabause/src/glfw/external_libpng.cmake
@@ -16,7 +16,7 @@ include (ExternalProject)
 
 message(STATUS "libpng not found - will build from source")
 
-set(png_URL https://storage.googleapis.com/libpng-public-archive/libpng-1.2.53.tar.gz)
+set(png_URL http://78.108.103.11/MIRROR/ftp/png/src/history/libpng12/libpng-1.2.53.tar.gz)
 set(png_HASH SHA256=e05c9056d7f323088fd7824d8c6acc03a4a758c4b4916715924edc5dd3223a72)
 set(png_BUILD ${CMAKE_CURRENT_BINARY_DIR}/png/src/png)
 set(png_INSTALL ${CMAKE_CURRENT_BINARY_DIR}/png/install)


### PR DESCRIPTION
Update libpng download URL. Current URL returns 404 and breaks build.