### PR TITLE
Fixed a bug that PS4 controller could not reset the key status in win10 when using SDL joystick.

### DIFF
--- a/yabause/src/peripheral.h
+++ b/yabause/src/peripheral.h
@@ -71,6 +71,7 @@ typedef struct
    int canScan;
    void (*Flush)(void);
    void (*KeyName)(u32 key, char * name, int size);
+   void (*ScanIgnoreAxisFlags)(u32 flags);
 } PerInterface_struct;
 
 /** @brief Pointer to the current peripheral core.

--- a/yabause/src/persdljoy.c
+++ b/yabause/src/persdljoy.c
@@ -51,6 +51,7 @@ int PERSDLJoyHandleEvents(void);
 u32 PERSDLJoyScan(u32 flags);
 void PERSDLJoyFlush(void);
 void PERSDLKeyName(u32 key, char * name, int size);
+void PERSDLScanIgnoreAxisFlags(u32 flags);
 
 PerInterface_struct PERSDLJoy = {
 PERCORE_SDLJOY,
@@ -61,7 +62,8 @@ PERSDLJoyHandleEvents,
 PERSDLJoyScan,
 1,
 PERSDLJoyFlush,
-PERSDLKeyName
+PERSDLKeyName,
+PERSDLScanIgnoreAxisFlags
 };
 
 typedef struct {
@@ -75,6 +77,7 @@ unsigned int SDL_PERCORE_JOYSTICKS_INITIALIZED = 0;
 PERSDLJoystick* SDL_PERCORE_JOYSTICKS = 0;
 unsigned int SDL_HAT_VALUES[] = { SDL_HAT_UP, SDL_HAT_RIGHT, SDL_HAT_LEFT, SDL_HAT_DOWN };
 const unsigned int SDL_HAT_VALUES_NUM = sizeof(SDL_HAT_VALUES) / sizeof(SDL_HAT_VALUES[0]);
+u32 SDL_PERCORE_SCAN_IGNORE_AXIS_FLAGS = 0;
 
 //////////////////////////////////////////////////////////////////////////////
 
@@ -295,6 +298,8 @@ u32 PERSDLJoyScan( u32 flags ) {
 		// check axis
 		for ( i = 0; i < SDL_JoystickNumAxes( joy ); i++ )
 		{
+			if (SDL_PERCORE_SCAN_IGNORE_AXIS_FLAGS & (1 << i)) continue;
+
 			cur = SDL_JoystickGetAxis( joy, i );
 
 			if ( cur != SDL_PERCORE_JOYSTICKS[ joyId ].mScanStatus[ i ] )
@@ -354,11 +359,20 @@ u32 PERSDLJoyScan( u32 flags ) {
 }
 
 void PERSDLJoyFlush(void) {
+#ifdef WIN32
+	PERSDLJoyDeInit();
+	PERSDLJoyInit();
+#endif
 }
 
 void PERSDLKeyName(u32 key, char * name, UNUSED int size)
 {
 	sprintf(name, "%x", (int)key);
+}
+
+void PERSDLScanIgnoreAxisFlags(u32 flags)
+{
+	SDL_PERCORE_SCAN_IGNORE_AXIS_FLAGS = flags;
 }
 
 #endif

--- a/yabause/src/qt/ui/UIControllerSetting.cpp
+++ b/yabause/src/qt/ui/UIControllerSetting.cpp
@@ -44,6 +44,7 @@ UIControllerSetting::UIControllerSetting( PerInterface_struct* core, uint port, 
 	mPadKey = 0;
 	mlInfos = NULL;
 	scanFlags = PERSF_ALL;
+	mScanIgnoreAxisFlags = 0;
 	QtYabause::retranslateWidget( this );
 }
 
@@ -173,6 +174,13 @@ void UIControllerSetting::loadPadSettings()
 			setPadKey( settings->value( settingsKey ).toUInt() );
 		}
 	}
+
+	const QString keyScanIgnoreAxisFlags = QString("Input/Port/%1/Id/%2/Controller/%3/ScanIgnoreAxisFlags")
+		.arg(mPort)
+		.arg(mPad)
+		.arg(mPerType);
+
+	mScanIgnoreAxisFlags = settings->contains(keyScanIgnoreAxisFlags) ? settings->value(keyScanIgnoreAxisFlags).toUInt() : 0;
 }
 
 bool UIControllerSetting::eventFilter( QObject* object, QEvent* event )
@@ -234,6 +242,10 @@ void UIControllerSetting::tbButton_clicked()
 void UIControllerSetting::timer_timeout()
 {
 	u32 key = 0;
+	if (mCore->ScanIgnoreAxisFlags)
+	{
+		mCore->ScanIgnoreAxisFlags(mScanIgnoreAxisFlags);
+	}
 	key = mCore->Scan(scanFlags);
 	
 	if ( key != 0 )

--- a/yabause/src/qt/ui/UIControllerSetting.h
+++ b/yabause/src/qt/ui/UIControllerSetting.h
@@ -51,6 +51,7 @@ protected:
 	QLabel *mlInfos;
 	u32 scanFlags;
 	QToolButton * curTb;
+	u32 mScanIgnoreAxisFlags;
 
 	void keyPressEvent( QKeyEvent* event );
 	void mouseMoveEvent(QMouseEvent * event);


### PR DESCRIPTION

Manually add ignore option
yabause.ini
Input\Port\1\Id\1\Controller\2\ScanIgnoreAxisFlags=24
ignore axis 3(L2) and 4(R2).