### PR TITLE
System language change functionality

### DIFF
--- a/yabause/src/android/jni/yui.cpp
+++ b/yabause/src/android/jni/yui.cpp
@@ -1254,6 +1254,7 @@ int YabauseInit(){
     yinit.cdcoretype = CDCORE_ISO;
     yinit.carttype = GetCartridgeType();
     yinit.regionid = 0;
+    yinit.syslanguageid = 0;
 
     yinit.biospath = s_biospath;
     yinit.cdpath = s_cdpath;

--- a/yabause/src/cocoa/YabauseController.m
+++ b/yabause/src/cocoa/YabauseController.m
@@ -256,6 +256,7 @@ static void FlipToggle(NSMenuItem *item) {
         yinit.cdcoretype = cdcore;
         yinit.carttype = [prefs cartType];
         yinit.regionid = [prefs region];
+        yinit.syslanguageid = [prefs system language];
         yinit.biospath = ([bios length] > 0 && ![prefs emulateBios]) ?
             [bios UTF8String] : NULL;
         yinit.cdpath = fn;

--- a/yabause/src/dreamcast/yui.c
+++ b/yabause/src/dreamcast/yui.c
@@ -87,6 +87,7 @@ int YuiInit(int sh2core)   {
     yinit.cdcoretype = CDCORE_ARCH;
     yinit.carttype = CART_NONE;
     yinit.regionid = REGION_AUTODETECT;
+    yinit.syslanguageid = 0;
     yinit.biospath = emulate_bios ? NULL : bios;
     yinit.cdpath = NULL;
     yinit.buppath = NULL;

--- a/yabause/src/glfw/main.cpp
+++ b/yabause/src/glfw/main.cpp
@@ -230,6 +230,7 @@ int yabauseinit()
   yinit.cdcoretype = CDCORE_ISO;
   yinit.carttype = CART_NONE;
   yinit.regionid = 0;
+  yinit.syslanguageid = 0;
   yinit.biospath = biospath;
   yinit.cdpath = cdpath;
   yinit.buppath = buppath;

--- a/yabause/src/gtk/main.c
+++ b/yabause/src/gtk/main.c
@@ -131,6 +131,11 @@ GtkWidget * yui;
 GKeyFile * keyfile;
 yabauseinit_struct yinit;
 
+char* toLower(char* s) {
+  for(char *p=s; *p; p++) *p=tolower(*p);
+  return s;
+}
+
 static int yui_main(gpointer data) {
 	PERCore->HandleEvents();
 	return TRUE;

--- a/yabause/src/gtk/main.c
+++ b/yabause/src/gtk/main.c
@@ -163,6 +163,7 @@ static void yui_settings_init(void) {
 	yinit.carttype = CART_NONE;
 	yinit.regionid = 0;
 	yinit.biospath = biospath;
+	yinit.syslanguageid = 0;
 	yinit.cdpath = cdpath;
 	yinit.buppath = buppath;
 	yinit.mpegpath = mpegpath;
@@ -227,6 +228,28 @@ static gboolean yui_settings_load(void) {
 		Cs2ChangeCDCore(yinit.cdcoretype, yinit.cdpath);
 	}
 
+	/* SystemLanguageID */
+	{
+		char * syslang = g_key_file_get_value(keyfile, "General", "SystemLanguageID", 0);
+		tmp = yinit.syslanguageid;
+		if ((syslang == 0) || !strcmp(syslang, "0")) {
+			yinit.syslanguageid = 0;
+		} else {
+			switch(syslang[0]) {
+				case '0': yinit.syslanguageid = 0; break;
+				case '1': yinit.syslanguageid = 1; break;
+				case '2': yinit.syslanguageid = 2; break;
+				case '3': yinit.syslanguageid = 3; break;
+				case '4': yinit.syslanguageid = 4; break;
+				case '5': yinit.syslanguageid = 5; break;
+			}
+		}
+
+		if ((YUI_WINDOW(yui)->state & YUI_IS_INIT) && (tmp != yinit.syslanguageid)) {
+			mustRestart = TRUE;
+		}
+	}
+	
 	/* region */
 	{
 		char * region = g_key_file_get_value(keyfile, "General", "Region", 0);
@@ -494,6 +517,24 @@ int main(int argc, char *argv[]) {
 	 } else if (strstr(argv[i], "--bios=")) {
             g_strlcpy(biospath, argv[i] + strlen("--bios="), 256);
             yinit.biospath = biospath;
+	 }
+	 //set System Language
+         if (0 == strcmp(argv[i], "-l") && argv[i + 1]) {
+            g_strlcpy(strsyslangeid, argv[i + 1], 256);
+            if (toLower(strsyslangeid) == "english") { yinit.syslanguageid = 0; }
+            if (toLower(strsyslangeid) == "deutsch") { yinit.syslanguageid = 1; }
+            if (toLower(strsyslangeid) == "french") { yinit.syslanguageid = 2; }
+            if (toLower(strsyslangeid) == "spanish") { yinit.syslanguageid = 3; }
+            if (toLower(strsyslangeid) == "italian") { yinit.syslanguageid = 4; }
+            if (toLower(strsyslangeid) == "japanese") { yinit.syslanguageid = 5; }
+	 } else if (strstr(argv[i], "--language=")) {
+            g_strlcpy(strsyslangeid, argv[i] + strlen("--language="), 256);
+            if (toLower(strsyslangeid) == "english") { yinit.syslanguageid = 0; }
+            if (toLower(strsyslangeid) == "deutsch") { yinit.syslanguageid = 1; }
+            if (toLower(strsyslangeid) == "french") { yinit.syslanguageid = 2; }
+            if (toLower(strsyslangeid) == "spanish") { yinit.syslanguageid = 3; }
+            if (toLower(strsyslangeid) == "italian") { yinit.syslanguageid = 4; }
+            if (toLower(strsyslangeid) == "japanese") { yinit.syslanguageid = 5; }
 	 }
          //set iso
          else if (0 == strcmp(argv[i], "-i") && argv[i + 1]) {

--- a/yabause/src/gtk/settings.c
+++ b/yabause/src/gtk/settings.c
@@ -80,6 +80,16 @@ YuiRangeItem * osdcores = NULL;
 YuiRangeItem * sndcores = NULL;
 YuiRangeItem * percores = NULL;
 
+YuiRangeItem syslanguage[] = {
+	{ "0" , "English" },
+	{ "1" , "Deutsch" },
+	{ "2" , "French" },
+	{ "3" , "Spanish" },
+	{ "4" , "Italian" },
+	{ "5" , "Japanese" },
+	{ 0, 0 }
+};
+
 YuiRangeItem regions[] = {
 	{ "Auto" , "Auto-detect" },
 	{ "J" , "Japan (NTSC)" },
@@ -324,7 +334,10 @@ GtkWidget* create_dialog1(void) {
 
   box = yui_page_add(YUI_PAGE(general), _("Save States"));
   gtk_container_add(GTK_CONTAINER(box), yui_file_entry_new(keyfile, "General", "StatePath", YUI_FILE_ENTRY_BROWSE | YUI_FILE_ENTRY_DIRECTORY, NULL));
-  
+
+  box = yui_page_add(YUI_PAGE(general), _("System Language"));
+  gtk_container_add(GTK_CONTAINER(box), yui_range_new(keyfile, "General", "SystemLanguageID", syslanguage));
+	
   gtk_notebook_append_page(GTK_NOTEBOOK(notebook1), general, gtk_label_new (_("General")));
   gtk_widget_show_all(general);
 

--- a/yabause/src/ios/yui.cpp
+++ b/yabause/src/ios/yui.cpp
@@ -159,6 +159,7 @@ int start_emulation( int originx, int originy, int width, int height ){
     yinit.sndcoretype = SNDCORE_AL; //SNDCORE_DEFAULT;
     yinit.cdcoretype = CDCORE_ISO;
     yinit.regionid = 0;
+    yinit.syslanguageid = 0;
 
     yinit.biospath = s_biospath;
     yinit.cdpath = s_cdpath;

--- a/yabause/src/libretro/libretro.c
+++ b/yabause/src/libretro/libretro.c
@@ -41,6 +41,7 @@ static char g_system_dir[PATH_MAX];
 static char full_path[PATH_MAX];
 static char bios_path[PATH_MAX];
 static char bup_path[PATH_MAX];
+static int system_language = 0;
 
 static int game_width  = 320;
 static int game_height = 240;
@@ -89,6 +90,11 @@ static retro_input_state_t input_state_cb;
 static retro_environment_t environ_cb;
 static retro_audio_sample_batch_t audio_batch_cb;
 
+char* toLower(char* s) {
+  for(char *p=s; *p; p++) *p=tolower(*p);
+  return s;
+}
+
 #if defined(_USEGLEW_)
 static struct retro_hw_render_callback hw_render;
 #else
@@ -101,6 +107,7 @@ void retro_set_environment(retro_environment_t cb)
       { "yabasanshiro_force_hle_bios", "Force HLE BIOS (restart, deprecated, debug only); disabled|enabled" },
       { "yabasanshiro_frameskip", "Auto-frameskip (prevent fast-forwarding); enabled|disabled" },
       { "yabasanshiro_addon_cart", "Addon Cartridge (restart); 4M_extended_ram|1M_extended_ram" },
+      { "yabasanshiro_system_language", "english, deutsch, french, spanish, italian, japanese" },
       { "yabasanshiro_multitap_port1", "6Player Adaptor on Port 1; disabled|enabled" },
       { "yabasanshiro_multitap_port2", "6Player Adaptor on Port 2; disabled|enabled" },
 #ifdef DYNAREC_DEVMIYAX
@@ -750,6 +757,24 @@ void check_variables(void)
          addon_cart_type = CART_DRAM32MBIT;
    }
 
+   var.key = "yabasanshiro_system_language";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      {
+      if (strcmp(toLower(var.value), "english") == 0)
+         system_language = 0;
+      else if (strcmp(toLower(var.value), "deutsch") == 0)
+         system_language = 1;
+      else if (strcmp(toLower(var.value), "french") == 0)
+         system_language = 2;
+      else if (strcmp(toLower(var.value), "spanish") == 0)
+         system_language = 3;
+      else if (strcmp(toLower(var.value), "italian") == 0)
+         system_language = 4;
+      else if (strcmp(toLower(var.value), "japanese") == 0)
+         system_language = 5;
+   }
+ 
    var.key = "yabasanshiro_multitap_port1";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
@@ -1253,6 +1278,7 @@ bool retro_load_game(const struct retro_game_info *info)
    yinit.cdcoretype       = CDCORE_ISO;
    yinit.cdpath           = full_path;
    yinit.biospath         = (hle_bios_force ? NULL : bios_path);
+   yinit.syslanguageid = system_language;
    yinit.carttype         = addon_cart_type;
    yinit.cartpath         = "\0";
 

--- a/yabause/src/nx/main.cpp
+++ b/yabause/src/nx/main.cpp
@@ -112,6 +112,8 @@ void userAppExit()
 
 extern "C" {
 static char biospath[256] = "./yabasanshiro/bios.bin";
+static char strgsyslangeid[256] = "english";
+static int syslanguageid = 0;
 static char cdpath[256] = "./yabasanshiro/nights.cue";
 //static char cdpath[256] = "/home/pigaming/RetroPie/roms/saturn/gd.cue";
 //static char cdpath[256] = "/home/pigaming/RetroPie/roms/saturn/Virtua Fighter Kids (1996)(Sega)(JP).ccd";
@@ -201,6 +203,11 @@ string g_keymap_filename;
 
 #include "nanovg.h"
 
+char* toLower(char* s) {
+  for(char *p=s; *p; p++) *p=tolower(*p);
+  return s;
+}
+	
 //----------------------------------------------------------------------------------------------
 NVGcontext * getGlobalNanoVGContext(){
   return NULL;
@@ -268,6 +275,7 @@ int yabauseinit()
   yinit.cdcoretype = CDCORE_ISO;
   yinit.carttype = CART_NONE;
   yinit.regionid = 0;
+  yinit.syslanguageid = syslanguageid;
   if( g_emulated_bios ){
     yinit.biospath = NULL;
   }else{
@@ -421,6 +429,7 @@ int main(int argc, char** argv)
     if( all_args[0] == "-h" || all_args[0] == "--h" ){
       printf("Usage:\n");
       printf("  -b STRING  --bios STRING                 bios file\n");
+      printf("  -l STRING  --language STRING             english, deutsch, french, spanish,\n                                           italian, japanese\n");
       printf("  -i STRING  --iso STRING                  iso/cue file\n");
       printf("  -r NUMBER  --resolution_mode NUMBER      0 .. Native, 1 .. 4x, 2 .. 2x, 3 .. Original\n");
       printf("  -a         --keep_aspect_rate\n");
@@ -436,6 +445,15 @@ int main(int argc, char** argv)
 		if(( x == "-b" || x == "--bios") && (i+1<all_args.size() ) ) {
       g_emulated_bios = 0;
       strncpy(biospath, all_args[i+1].c_str(), 256);
+    }
+	  	else if(( x == "-l" || x == "--language") && (i+1<all_args.size() ) ) {
+      strncpy(strgsyslangeid, all_args[i+1].c_str(), 256);
+	  if (toLower(strgsyslangeid) == "english") { yinit.syslanguageid = 0; }
+	  if (toLower(strgsyslangeid) == "deutsch") { yinit.syslanguageid = 1; }
+	  if (toLower(strgsyslangeid) == "french") { yinit.syslanguageid = 2; }
+	  if (toLower(strgsyslangeid) == "spanish") { yinit.syslanguageid = 3; }
+	  if (toLower(strgsyslangeid) == "italian") { yinit.syslanguageid = 4; }
+	  if (toLower(strgsyslangeid) == "japanese") { yinit.syslanguageid = 5; }
     }
 		else if(( x == "-i" || x == "--iso") && (i+1<all_args.size() ) ) {
       strncpy(cdpath, all_args[i+1].c_str(), 256);

--- a/yabause/src/qt/Arguments.cpp
+++ b/yabause/src/qt/Arguments.cpp
@@ -23,6 +23,7 @@ namespace Arguments
 	void autostart(const QString& param);
 	void binary(const QString& param);
 	void bios(const QString& param);
+	void syslangid(const QString& param);
 	void cdrom(const QString& param);
 	void fullscreen(const QString& param);
 	void help(const QString& param);
@@ -51,6 +52,7 @@ namespace Arguments
 		{ "-a",  "--autostart", NULL,       "Automatically start emulation.",                      1, autostart },
 		{ NULL,  "--binary=", "<FILE>[:ADDRESS]", "Use a binary file.",                           1, binary },
 		{ "-b",  "--bios=", "<BIOS>",       "Choose a bios file.",                                3, bios },
+		{ "-l",  "--language=", "<language>","Choose the system language: english, deutsch, french, spanish, italian, japanese",                     7, syslangid },
 		{ "-c",  "--cdrom=", "<CDROM>",     "Choose the cdrom device.",                           4, cdrom },
 		{ "-f",  "--fullscreen", NULL,      "Start the emulator in fullscreen.",                  5, fullscreen },
     { "-p",  "--playrecord", "<DIR>",   "Play play record.",                  5, playRecord },
@@ -64,8 +66,8 @@ namespace Arguments
 
 	void parse()
 	{
-		QVector<Option *> choosenOptions(7);
-		QVector<QString> params(7);
+		QVector<Option *> choosenOptions(8);
+		QVector<QString> params(8);
 
 		QStringList arguments = QApplication::arguments();
 		QStringListIterator argit(arguments);
@@ -92,7 +94,7 @@ namespace Arguments
 			}
 		}
 		
-		for(int i = 0;i < 7;i++)
+		for(int i = 0;i < 8;i++)
 		{
 			Option * option = choosenOptions[i];
 			if (option)
@@ -150,6 +152,17 @@ namespace Arguments
 		vs->setValue("General/Bios", param);
 	}
 
+	void syslangid(const QString& param)
+	{
+		VolatileSettings * vs = QtYabause::volatileSettings();
+		if (param.toLower() == "english") { vs->setValue("General/SystemLanguageID", 0); }
+		if (param.toLower() == "deutsch") { vs->setValue("General/SystemLanguageID", 1); }
+		if (param.toLower() == "french") { vs->setValue("General/SystemLanguageID", 2); }
+		if (param.toLower() == "spanish") { vs->setValue("General/SystemLanguageID", 3); }
+		if (param.toLower() == "italian") { vs->setValue("General/SystemLanguageID", 4); }
+		if (param.toLower() == "japanese") { vs->setValue("General/SystemLanguageID", 5); }
+	}
+	
 	void cdrom(const QString& param)
 	{
 		VolatileSettings * vs = QtYabause::volatileSettings();

--- a/yabause/src/qt/YabauseThread.cpp
+++ b/yabause/src/qt/YabauseThread.cpp
@@ -449,6 +449,21 @@ void YabauseThread::reloadSettings()
 			case 'L': mYabauseConf.regionid = 0xD; break;
 		}
 	}
+	const QString r1 = vs->value( "General/SystemLanguageID", mYabauseConf.syslanguageid ).toString();
+	if ( r1.isEmpty() || r1 == "0" )
+		mYabauseConf.syslanguageid = 0;
+	else
+	{
+		switch ( r1[0].toLatin1() )
+		{
+			case '0': mYabauseConf.syslanguageid = 0; break;
+			case '1': mYabauseConf.syslanguageid = 1; break;
+			case '2': mYabauseConf.syslanguageid = 2; break;
+			case '3': mYabauseConf.syslanguageid = 3; break;
+			case '4': mYabauseConf.syslanguageid = 4; break;
+			case '5': mYabauseConf.syslanguageid = 5; break;
+		}
+	}
 	if (vs->value("General/EnableEmulatedBios", false).toBool())
 		mYabauseConf.biospath = strdup( "" );
 	else
@@ -531,6 +546,7 @@ void YabauseThread::resetYabauseConf()
 	mYabauseConf.cdcoretype = QtYabause::defaultCDCore().id;
 	mYabauseConf.carttype = CART_NONE;
 	mYabauseConf.regionid = 0;
+	mYabauseConf.syslanguageid = 0;
 	mYabauseConf.biospath = 0;
 	mYabauseConf.cdpath = 0;
 	mYabauseConf.mpegpath = 0;

--- a/yabause/src/qt/ui/UISettings.cpp
+++ b/yabause/src/qt/ui/UISettings.cpp
@@ -51,6 +51,14 @@ struct Item
 
 typedef QList<Item> Items;
 
+const Items mSysLanguageID = Items()
+	<< Item( "0", "English" )
+	<< Item( "1", "Deutsch" )
+	<< Item( "2", "French" )
+	<< Item( "3", "Spanish" )
+	<< Item( "4", "Italian" )
+	<< Item( "5", "Japanese" );
+
 const Items mRegions = Items()
 	<< Item( "Auto" , "Auto-detect" )
 	<< Item( "J" , "Japan (NTSC)" )
@@ -373,6 +381,10 @@ void UISettings::loadCores()
 	foreach ( const Item& it, mRegions )
 		cbRegion->addItem( QtYabause::translate( it.Name ), it.id );
 	
+	// System Language
+	foreach ( const Item& it, mSysLanguageID  )
+		cbSysLanguageID ->addItem( QtYabause::translate( it.Name ), it.id );
+	
 	// SH2 Interpreters
 	for ( int i = 0; SH2CoreList[i] != NULL; i++ )
 		cbSH2Interpreter->addItem( QtYabause::translate( SH2CoreList[i]->Name ), SH2CoreList[i]->id );
@@ -471,6 +483,7 @@ void UISettings::loadSettings()
 		cbCdDrive->setCurrentIndex(leCdRom->text().isEmpty() ? 0 : cbCdDrive->findText(leCdRom->text()));
 
 	leSaveStates->setText( s->value( "General/SaveStates", getDataDirPath() ).toString() );
+	cbSysLanguageID->setCurrentIndex( cbSysLanguageID->findData( s->value( "General/SystemLanguageID", mSysLanguageID.at( 0 ).id ).toString() ) );
 #ifdef HAVE_LIBMINI18N
 	int i;
 	if ((i=cbTranslation->findData(s->value( "General/Translation" ).toString())) != -1)
@@ -579,6 +592,7 @@ void UISettings::saveSettings()
 	else
 		s->setValue( "General/CdRomISO", leCdRom->text() );
 	s->setValue( "General/SaveStates", leSaveStates->text() );
+	s->setValue( "General/SystemLanguageID", cbSysLanguageID->itemData( cbSysLanguageID->currentIndex() ).toString() );
 #ifdef HAVE_LIBMINI18N
 	s->setValue( "General/Translation", cbTranslation->itemData(cbTranslation->currentIndex()).toString() );
 #endif

--- a/yabause/src/qt/ui/UISettings.ui
+++ b/yabause/src/qt/ui/UISettings.ui
@@ -117,6 +117,25 @@
         </widget>
        </item>
        <item row="10" column="0" colspan="2">
+        <widget class="QLabel" name="lSysLanguageID">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>System Language</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="0" colspan="2">
+        <widget class="QComboBox" name="cbSysLanguageID"/>
+       </item>
+       <item row="12" column="0" colspan="2">
         <widget class="QLabel" name="lTranslation">
          <property name="font">
           <font>
@@ -186,7 +205,7 @@
          </property>
         </widget>
        </item>
-       <item row="11" column="0" colspan="2">
+       <item row="13" column="0" colspan="2">
         <widget class="QComboBox" name="cbTranslation"/>
        </item>
        <item row="20" column="0">

--- a/yabause/src/qt/ui/UIYabause.cpp
+++ b/yabause/src/qt/ui/UIYabause.cpp
@@ -847,6 +847,7 @@ void UIYabause::on_aFileSettings_triggered()
          newhash["Advanced/68kCore"] != hash["Advanced/68kCore"] ||
 			newhash["General/CdRom"]!=hash["General/CdRom"] ||
 			newhash["General/CdRomISO"]!=hash["General/CdRomISO"] ||
+		   	newhash["General/SystemLanguageID"]!=hash["General/SystemLanguageID"] ||
 			newhash["General/ClockSync"]!=hash["General/ClockSync"] ||
 			newhash["General/FixedBaseTime"]!=hash["General/FixedBaseTime"]
 		)

--- a/yabause/src/retro_arena/main.cpp
+++ b/yabause/src/retro_arena/main.cpp
@@ -76,6 +76,8 @@ char s_savepath[256] ="\0";
 
 extern "C" {
 static char biospath[256] = "/home/pigaming/RetroPie/BIOS/saturn/bios.bin";
+static char strgsyslangeid[256] = "english";
+static int syslanguageid = 0;
 static char cdpath[256] = ""; ///home/pigaming/RetroPie/roms/saturn/nights.cue";
 //static char cdpath[256] = "/home/pigaming/RetroPie/roms/saturn/gd.cue";
 //static char cdpath[256] = "/home/pigaming/RetroPie/roms/saturn/Virtua Fighter Kids (1996)(Sega)(JP).ccd";
@@ -83,6 +85,11 @@ static char buppath[256] = "./back.bin";
 static char mpegpath[256] = "\0";
 static char cartpath[256] = "\0";
 static bool menu_show = false;
+
+char* toLower(char* s) {
+  for(char *p=s; *p; p++) *p=tolower(*p);
+  return s;
+}
 
 #define LOG printf
 
@@ -226,6 +233,7 @@ int yabauseinit()
   yinit.cdcoretype = CDCORE_ISO;
   yinit.carttype = CART_DRAM32MBIT;
   yinit.regionid = 0;
+  yinit.syslanguageid = syslanguageid;
   if( g_emulated_bios ){
     yinit.biospath = NULL;
   }else{
@@ -302,6 +310,7 @@ int main(int argc, char** argv)
     if( all_args[0] == "-h" || all_args[0] == "--h" ){
       printf("Usage:\n");
       printf("  -b STRING  --bios STRING                 bios file\n");
+      printf("  -l STRING  --language STRING             english, deutsch, french, spanish,\n                                           italian, japanese\n");
       printf("  -i STRING  --iso STRING                  iso/cue file\n");
       printf("  -r NUMBER  --resolution_mode NUMBER      0 .. Native, 1 .. 4x, 2 .. 2x, 3 .. Original\n");
       printf("  -a         --keep_aspect_rate\n");
@@ -317,6 +326,15 @@ int main(int argc, char** argv)
 		if(( x == "-b" || x == "--bios") && (i+1<all_args.size() ) ) {
       g_emulated_bios = 0;
       strncpy(biospath, all_args[i+1].c_str(), 256);
+    }
+	  	else if(( x == "-l" || x == "--language") && (i+1<all_args.size() ) ) {
+      strncpy(strgsyslangeid, all_args[i+1].c_str(), 256);
+	  if (toLower(strgsyslangeid) == "english") { syslanguageid = 0; }
+	  if (toLower(strgsyslangeid) == "deutsch") { syslanguageid = 1; }
+	  if (toLower(strgsyslangeid) == "french") { syslanguageid = 2; }
+	  if (toLower(strgsyslangeid) == "spanish") { syslanguageid = 3; }
+	  if (toLower(strgsyslangeid) == "italian") { syslanguageid = 4; }
+	  if (toLower(strgsyslangeid) == "japanese") { syslanguageid = 5; }
     }
 		else if(( x == "-i" || x == "--iso") && (i+1<all_args.size() ) ) {
       strncpy(cdpath, all_args[i+1].c_str(), 256);

--- a/yabause/src/runner/yui.cpp
+++ b/yabause/src/runner/yui.cpp
@@ -549,6 +549,7 @@ namespace game_testing
       yinit.cdcoretype = CDCORE_ISO;
       yinit.carttype = CART_NONE;
       yinit.regionid = REGION_AUTODETECT;
+      yinit.syslanguageid = 0;
       yinit.biospath = emulate_bios ? NULL : bios;
       yinit.cdpath = full_path.c_str();
       yinit.buppath = NULL;
@@ -796,6 +797,7 @@ namespace yabauseut
       yinit.cdcoretype = CDCORE_DUMMY;
       yinit.carttype = CART_NONE;
       yinit.regionid = REGION_AUTODETECT;
+      yinit.syslanguageid = 0;
       yinit.biospath = emulate_bios ? NULL : bios;
       yinit.cdpath = NULL;
       yinit.buppath = NULL;

--- a/yabause/src/sdl/main.c
+++ b/yabause/src/sdl/main.c
@@ -144,6 +144,8 @@ static int fullscreen = 0;
 static int lowres_mode = 0;
 
 static char biospath[256] = "\0";
+static char strgsyslangeid[256] = "english";
+static int syslanguageid = 0;
 static char cdpath[256] = "\0";
 
 GLFWwindow* g_window = NULL;
@@ -151,6 +153,10 @@ GLFWwindow* g_offscreen_context;
 
 yabauseinit_struct yinit ={};
 
+char* toLower(char* s) {
+  for(char *p=s; *p; p++) *p=tolower(*p);
+  return s;
+}
 void YuiErrorMsg(const char * string) {
     fprintf(stderr, "%s\n\r", string);
 }
@@ -227,6 +233,7 @@ void YuiInit() {
 	yinit.cdcoretype = CDCORE_DEFAULT;
 	yinit.carttype = CART_DRAM32MBIT;
 	yinit.regionid = REGION_EUROPE;
+	yinit.syslanguageid = syslanguageid;
 	yinit.biospath = NULL;
 	yinit.cdpath = NULL;
 	yinit.buppath = NULL;
@@ -319,6 +326,24 @@ int main(int argc, char *argv[]) {
       } else if (strstr(argv[i], "--bios=")) {
         strncpy(biospath, argv[i] + strlen("--bios="), 256);
         yinit.biospath = biospath;
+      }
+      //set System Language
+      if (0 == strcmp(argv[i], "-l") && argv[i + 1]) {
+        strncpy(strgsyslangeid, argv[i + 1], 256);
+        if (toLower(strgsyslangeid) == "english") { yinit.syslanguageid = 0; }
+        if (toLower(strgsyslangeid) == "deutsch") { yinit.syslanguageid = 1; }
+        if (toLower(strgsyslangeid) == "french") { yinit.syslanguageid = 2; }
+        if (toLower(strgsyslangeid) == "spanish") { yinit.syslanguageid = 3; }
+        if (toLower(strgsyslangeid) == "italian") { yinit.syslanguageid = 4; }
+        if (toLower(strgsyslangeid) == "japanese") { yinit.syslanguageid = 5; }
+      } else if (strstr(argv[i], "--language=")) {
+        strncpy(strgsyslangeid, argv[i] + strlen("--language="), 256);
+        if (toLower(strgsyslangeid) == "english") { yinit.syslanguageid = 0; }
+        if (toLower(strgsyslangeid) == "deutsch") { yinit.syslanguageid = 1; }
+        if (toLower(strgsyslangeid) == "french") { yinit.syslanguageid = 2; }
+        if (toLower(strgsyslangeid) == "spanish") { yinit.syslanguageid = 3; }
+        if (toLower(strgsyslangeid) == "italian") { yinit.syslanguageid = 4; }
+        if (toLower(strgsyslangeid) == "japanese") { yinit.syslanguageid = 5; }
       }
       //set iso
       else if (0 == strcmp(argv[i], "-i") && argv[i + 1]) {

--- a/yabause/src/smpc.c
+++ b/yabause/src/smpc.c
@@ -66,11 +66,12 @@ Smpc * SmpcRegs;
 u8 * SmpcRegsT;
 SmpcInternal * SmpcInternalVars = NULL;
 int intback_wait_for_line = 0;
+int syslngid = 0;
 u8 bustmp = 0;
 
 //////////////////////////////////////////////////////////////////////////////
 
-int SmpcInit(u8 regionid, int clocksync, u32 basetime) {
+int SmpcInit(u8 regionid, int syslanguageid, int clocksync, u32 basetime) {
    if ((SmpcRegsT = (u8 *) calloc(1, sizeof(Smpc))) == NULL)
       return -1;
  
@@ -81,6 +82,7 @@ int SmpcInit(u8 regionid, int clocksync, u32 basetime) {
   
    SmpcInternalVars->regionsetting = regionid;
    SmpcInternalVars->regionid = regionid;
+   SmpcInternalVars->syslanguageid = syslanguageid;
    SmpcInternalVars->clocksync = clocksync;
    SmpcInternalVars->basetime = basetime ? basetime : time(NULL);
 
@@ -129,7 +131,21 @@ void SmpcRecheckRegion(void) {
 
 void SmpcReset(void) {
    memset((void *)SmpcRegs, 0, sizeof(Smpc));
-   memset((void *)SmpcInternalVars->SMEM, 0, 4);
+   syslngid = SmpcInternalVars->syslanguageid;
+   memset((void *)SmpcInternalVars->SMEM, syslngid, 4); // Language : 0=English - 1=Deutsch - 2=French - 3=Spanish - 4=Italian - 5=Japanese
+   memset((void *)SmpcInternalVars->SMEM, 0, 3); // Other Settings - MUST BE DECLARED! - By default : 0 = Button Labels=Enabled + Audio=Stereo + Sound Effects=Enabled
+
+   //   Other Settings Configuration Information :
+   //
+   // |-------------------------------------------------------------------------------------------------------|
+   // |  Settings     | Bit / Settings Value                                                                  |
+   // |               |---------------------------------------------------------------------------------------|
+   // |    Name       |   0      |  1       |   2       |  3       |  4       |  5       |  6       |  7      |
+   // |-------------------------------------------------------------------------------------------------------|
+   // | Button Labels |  Enabled | Enabled  | Enabled  | Enabled  | Disabled | Disabled | Disabled | Disabled |
+   // | Audio         |  Stereo  | Stereo   | Mono     | Mono     | Stereo   | Stereo   | Mono     | Mono     |
+   // | Sound Effects |  Enabled | Disabled | Enabled  | Disabled | Enabled  | Disabled | Enabled  | Disabled |
+   // |-------------------------------------------------------------------------------------------------------|
 
    SmpcRecheckRegion();
 

--- a/yabause/src/smpc.h
+++ b/yabause/src/smpc.h
@@ -63,6 +63,8 @@ typedef struct
 
 typedef struct {
    u8 dotsel; // 0 -> 320 | 1 -> 352
+   int syslanguageid;
+   int syslngid;
    u8 mshnmi;
    u8 sndres;
    u8 cdres;
@@ -85,7 +87,7 @@ typedef struct {
 
 extern SmpcInternal * SmpcInternalVars;
 
-int SmpcInit(u8 regionid, int clocksync, u32 basetime);
+int SmpcInit(u8 regionid, int syslanguageid, int clocksync, u32 basetime);
 void SmpcDeInit(void);
 void SmpcRecheckRegion(void);
 void SmpcReset(void);

--- a/yabause/src/yabause.c
+++ b/yabause/src/yabause.c
@@ -143,6 +143,7 @@ void print_usage(const char *program_name) {
           "Usage: %s [OPTIONS]...\n", program_name);
    printf("   -h         --help                 Print help and exit\n");
    printf("   -b STRING  --bios=STRING          bios file\n");
+   printf("   -l STRING  --language=STRING      english, deutsch, french, spanish,\n                                     italian, japanese\n");
    printf("   -i STRING  --iso=STRING           iso/cue file\n");
    printf("   -c STRING  --cdrom=STRING         cdrom path\n");
    printf("   -ns        --nosound              turn sound off\n");
@@ -325,7 +326,7 @@ int YabauseInit(yabauseinit_struct *init)
       return -1;
    }
 
-   if (SmpcInit(init->regionid, init->clocksync, init->basetime) != 0)
+   if (SmpcInit(init->regionid, init->syslanguageid, init->clocksync, init->basetime) != 0)
    {
       YabSetError(YAB_ERR_CANNOTINIT, _("SMPC"));
       return -1;

--- a/yabause/src/yabause.h
+++ b/yabause/src/yabause.h
@@ -57,6 +57,7 @@ typedef struct
    int cdcoretype;
    int carttype;
    u8 regionid;
+   int syslanguageid;
    const char *biospath;
    const char *cdpath;
    const char *ssfpath;


### PR DESCRIPTION
Hello,

I offer this small contribution to allow changing the system language from the bios settings which is always in English after each start of the emulation.

With this modification, it is now possible to change the language from the "-l" or "--language" command line, then the option can also be modified from the application settings and then saved in the configuration file.

Some games, like Rayman for example, do not allow you to select the language and are based on the language configuration from the system settings. This can be annoying if a player wants to play their game in their native language or of their choice.

Test performed on Linux. The code can be changed if necessary. Tests may be necessary on other platforms to confirm the correct functioning of this new functionality.

The code is added for Retro Arena, Libretro, SDL and NX but must be tested.

Hoping that this contribution can interest you because it brings a comfort during the game to the player.